### PR TITLE
Get travis working with g2opy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
     - cd g2opy && mkdir build && cd build 
     - cmake -DPYTHON_EXECUTABLE=$(which python3) .. 
     - cat g2o/config.h
-    - make -w
+    - make -w -j8
     - cd .. 
     - python3 setup.py install
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
     - cmake ..
     - make 
     - cd .. 
-    - python setup.py install
+    - python3 setup.py install
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 dist: trusty
 compiler:
     - clang
+    - gcc
 os:
     - linux
 
@@ -23,6 +24,7 @@ install:
 script:
     - cd g2opy && mkdir build && cd build 
     - cmake ..
+    - cat g2o/config.h
     - make 
     - cd .. 
     - python3 setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,17 @@ notifications:
 
 before_install:
     - env | sort
-    - which python
     - sudo apt-get update -qq
     - sudo apt-get install -qq cmake qtdeclarative5-dev qt5-qmake libqglviewer-dev libeigen3-dev libsuitesparse-dev
 
-# install: 
-    # - git clone https://github.com/uoip/g2opy.git
-# script:
-    # - cd g2opy && mkdir build && cd build 
+install: 
+    - git clone https://github.com/uoip/g2opy.git
+script:
+    - cd g2opy && mkdir build && cd build 
     # - which python
-    # - cmake -DPYTHON_EXECUTABLE=$(which python) .. 
-    # - cat g2o/config.h
-    # - make 
-    # - cd .. 
-    # - python3 setup.py install
+    - cmake -DPYTHON_EXECUTABLE=$(which python3) .. 
+    - cat g2o/config.h
+    - make 
+    - cd .. 
+    - python3 setup.py install
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - git clone https://github.com/uoip/g2opy.git
 script:
     - cd g2opy && mkdir build && cd build 
-    - cmake ..
+    - cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(python-config --prefix)/bin/python3.5 -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython3.5m.so -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python3.5m .. 
     - cat g2o/config.h
     - make 
     - cd .. 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 sudo: required
-dist: xenial
+dist: trusty
 compiler:
     - clang
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ script:
     - cat g2o/config.h
     - make -w -j8
     - cd .. 
-    - python3 setup.py install
+    - sudo python3 setup.py install
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,18 @@ notifications:
 
 before_install:
     - env | sort
+    - which python
     - sudo apt-get update -qq
     - sudo apt-get install -qq cmake qtdeclarative5-dev qt5-qmake libqglviewer-dev libeigen3-dev libsuitesparse-dev
 
-install: 
-    - git clone https://github.com/uoip/g2opy.git
-script:
-    - cd g2opy && mkdir build && cd build 
-    - cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(python-config --prefix)/bin/python3.5 -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython3.5m.so -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python3.5m .. 
-    - cat g2o/config.h
-    - make 
-    - cd .. 
-    - python3 setup.py install
+# install: 
+    # - git clone https://github.com/uoip/g2opy.git
+# script:
+    # - cd g2opy && mkdir build && cd build 
+    # - which python
+    # - cmake -DPYTHON_EXECUTABLE=$(which python) .. 
+    # - cat g2o/config.h
+    # - make 
+    # - cd .. 
+    # - python3 setup.py install
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,9 @@ install:
     - git clone https://github.com/uoip/g2opy.git
 script:
     - cd g2opy && mkdir build && cd build 
-    # - which python
     - cmake -DPYTHON_EXECUTABLE=$(which python3) .. 
     - cat g2o/config.h
-    - make 
+    - make -w
     - cd .. 
     - python3 setup.py install
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: cpp
 sudo: required
-dist: trusty
+dist: xenial
 compiler:
-    - clang
     - gcc
 os:
     - linux
@@ -17,7 +16,7 @@ notifications:
 before_install:
     - env | sort
     - sudo apt-get update -qq
-    - sudo apt-get install -qq cmake qtdeclarative5-dev qt5-qmake libqglviewer-dev libeigen3-dev libsuitesparse-dev
+    - sudo apt-get install -qq cmake qtdeclarative5-dev qt5-qmake libqglviewer-dev libeigen3-dev libsuitesparse-dev python3-setuptools
 
 install: 
     - git clone https://github.com/uoip/g2opy.git


### PR DESCRIPTION
G2opy, a python binding of g2o. A lot of work to get travis working with it, tips:
1. ignore the warnings when building
2. build with multiple cores
3. use `xenial` 
4. explicitly point out which `python3` to use
5. use `sudo` for setup.py 